### PR TITLE
Update readme for the process install the buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ For more information, see [Heroku Integrations](https://devcenter.heroku.com/art
 ```shell
 heroku buildpacks:add heroku/heroku-buildpack-heroku-integration-service-mesh
 ```
+This doesn't work at the moment.
+
+```
+heroku buildpacks:add https://github.com/heroku/heroku-buildpack-heroku-integration-service-mesh -a <your_app_name>
+```
 
 ## Usage
 The Heroku Integration Service Mesh binary must be configured in your Procfile web process to start your app.


### PR DESCRIPTION
The current step is failing
```
 heroku buildpacks:add heroku/heroku-buildpack-heroku-integration-service-mesh --app akoul-public-us
zsh: correct 'heroku/heroku-buildpack-heroku-integration-service-mesh' to '.heroku/heroku-buildpack-heroku-integration-service-mesh' [nyae]? n
 ›   Error: Invalid buildpack ``
 ›
 ›   Error ID: invalid_params
```

The step that works is
```
heroku buildpacks:add https://github.com/heroku/heroku-buildpack-heroku-integration-service-mesh -a akoul-public-us
Buildpack added. Next release on akoul-public-us will use https://github.com/heroku/heroku-buildpack-heroku-integration-service-mesh.
Run git push heroku main to create a new release using this buildpack.
```