### PR TITLE
Ensure forward compatibility

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -71,6 +71,8 @@ if [ ! -f "$DOWNLOAD_INSTALL_DIR/$BINARY_FILE" ]; then
     exit 1
 fi
 
+ln -s "$BINARY_NAME" "$DOWNLOAD_INSTALL_DIR/heroku-applink-service-mesh"
+
 echo "Installing $BINARY_FILE..." | indent
 PROFILE_PATH="$BUILD_DIR/.profile.d/$BINARY_FILE.sh"
 mkdir -p $(dirname $PROFILE_PATH)


### PR DESCRIPTION
When AppLink ships, the buildpack-installed binary will be available as `heroku-applink-service-mesh` rather than `heroku-integration-service-mesh`.

I'm therefore creating a symbolic link from the existing binary to the new, eventual location. This allows us to transition documentation and sample projects without breaking any pilot use cases.